### PR TITLE
Pushing Heroku config updates to master

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: bundle exec puma -C config/puma.rb

--- a/app.json
+++ b/app.json
@@ -1,0 +1,33 @@
+{
+  "name": "Ada Internship Placement App",
+  "description": "Web application for exploring and deciding upon internship placement possibilities at Ada Developers Academy.",
+  "website": "https://placement.adadevelopersacademy.org/",
+  "repository": "https://github.com/Ada-Developers-Academy/internship-placement-app",
+  "buildpacks": [
+    {
+      "url": "heroku/ruby"
+    }
+  ],
+  "env": {
+    "SECRET_KEY_BASE": {
+      "description": "Large random value used for encrypting secrets (such as session cookies)",
+      "required": true,
+      "generator": "secret"
+    },
+    "GOOGLE_OAUTH_CLIENT_ID": {
+      "description": "Client ID for Google OAuth integration",
+      "required": true
+    },
+    "GOOGLE_OAUTH_CLIENT_SECRET": {
+      "description": "Client secret key for Google OAuth integration",
+      "required": true
+    }
+  },
+  "formation": {
+    "web": {
+      "quantity": 1,
+      "hobby"
+    }
+  },
+  "stack": "heroku-16"
+}

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -21,7 +21,7 @@ environment ENV.fetch("RAILS_ENV") { "development" }
 # Workers do not work on JRuby or Windows (both of which do not support
 # processes).
 #
-# workers ENV.fetch("WEB_CONCURRENCY") { 2 }
+workers ENV.fetch("WEB_CONCURRENCY") { 2 }
 
 # Use the `preload_app!` method when specifying a `workers` number.
 # This directive tells Puma to first boot the application and load code
@@ -30,7 +30,7 @@ environment ENV.fetch("RAILS_ENV") { "development" }
 # you need to make sure to reconnect any threads in the `on_worker_boot`
 # block.
 #
-# preload_app!
+preload_app!
 
 # The code in the `on_worker_boot` will be called if you are using
 # clustered mode by specifying a number of `workers`. After each worker
@@ -39,9 +39,9 @@ environment ENV.fetch("RAILS_ENV") { "development" }
 # or connections that may have been created at application boot, Ruby
 # cannot share connections between processes.
 #
-# on_worker_boot do
-#   ActiveRecord::Base.establish_connection if defined?(ActiveRecord)
-# end
+on_worker_boot do
+  ActiveRecord::Base.establish_connection if defined?(ActiveRecord)
+end
 
 # Allow puma to be restarted by `rails restart` command.
 plugin :tmp_restart


### PR DESCRIPTION
Besides just doing everything "correctly" according to Heroku's suggestions, the main reason for adding `app.json` and `Procfile` was that Heroku needs them in order to support Review Apps.

I think that the `app.json` change needs to be pushed to `master` before Heroku will actually detect that the file is present and allow me to enable Review Apps.