### PR TITLE
Implement automatic saving

### DIFF
--- a/app/assets/javascripts/backbone/views/placement_workbench_view.js
+++ b/app/assets/javascripts/backbone/views/placement_workbench_view.js
@@ -26,15 +26,12 @@ const PlacementWorkbenchView = Backbone.View.extend({
       this.addCompany(company);
     }, this);
 
-    // Do initial work around the list of companies.
-    this.updateUI();
-
     this.listenTo(this.model.companies, 'update', this.render);
     this.listenTo(this.model.companies, 'add', this.addCompany);
 
     this.undoManager.startTracking();
 
-    this.toggleButtons();
+    this.updateUI();
   },
 
   bindUserEvents: function() {

--- a/app/assets/javascripts/backbone/views/placement_workbench_view.js
+++ b/app/assets/javascripts/backbone/views/placement_workbench_view.js
@@ -133,7 +133,7 @@ const PlacementWorkbenchView = Backbone.View.extend({
     }
   },
 
-  onSave: function() {
+  onSave: _.debounce(function() {
     console.debug("Saving placement");
     result = this.model.save(null, {
       whiteboard: this.whiteboardElement.val(),
@@ -158,7 +158,7 @@ const PlacementWorkbenchView = Backbone.View.extend({
         toastr.error(text);
       }
     });
-  },
+  }, 300), // Batch all save attempts within a 300ms window
 
   onUndo: function() {
     console.debug("Undoing action");

--- a/app/assets/javascripts/backbone/views/placement_workbench_view.js
+++ b/app/assets/javascripts/backbone/views/placement_workbench_view.js
@@ -3,6 +3,7 @@ const PlacementWorkbenchView = Backbone.View.extend({
     this.bindUserEvents();
 
     this.whiteboardElement = this.$('#workbench-whiteboard textarea');
+    this.whiteboardElement.on('input', _.debounce(this.onSave.bind(this), 500));
 
     this.studentBus = new StudentBus();
     this.busDetails = new StudentBusView({

--- a/app/assets/javascripts/backbone/views/placement_workbench_view.js
+++ b/app/assets/javascripts/backbone/views/placement_workbench_view.js
@@ -48,6 +48,7 @@ const PlacementWorkbenchView = Backbone.View.extend({
 
   onCompanyChange: function() {
     this.updateUI();
+    this.onSave();
   },
 
   updateUI: function() {

--- a/app/assets/javascripts/backbone/views/placement_workbench_view.js
+++ b/app/assets/javascripts/backbone/views/placement_workbench_view.js
@@ -27,7 +27,7 @@ const PlacementWorkbenchView = Backbone.View.extend({
     }, this);
 
     // Do initial work around the list of companies.
-    this.onCompanyChange()
+    this.updateUI();
 
     this.listenTo(this.model.companies, 'update', this.render);
     this.listenTo(this.model.companies, 'add', this.addCompany);
@@ -50,6 +50,10 @@ const PlacementWorkbenchView = Backbone.View.extend({
   },
 
   onCompanyChange: function() {
+    this.updateUI();
+  },
+
+  updateUI: function() {
     // update scores
     let score = 0;
     this.model.companies.forEach(function(company) {


### PR DESCRIPTION
Now whenever we make changes to a placement attempt, those changes will be saved automatically.

I've left the "Save" button in the Placement Workbench UI in case the ability to manually trigger a save is still desirable. If no one ends up using it, then we should be able to safely remove it.