### PR TITLE
Interview feedback available again

### DIFF
--- a/app/models/ranking.rb
+++ b/app/models/ranking.rb
@@ -22,4 +22,10 @@ class Ranking < ApplicationRecord
   def interview
     Interview.find_by(student: student, company: company)
   end
+
+  def interview_result_reason
+    return nil unless interview && interview.has_feedback?
+
+    interview.interview_feedbacks.map(&:result_explanation).join("\n")
+  end
 end

--- a/app/models/ranking.rb
+++ b/app/models/ranking.rb
@@ -18,4 +18,8 @@ class Ranking < ApplicationRecord
   def score
     student_preference + interview_result
   end
+
+  def interview
+    Interview.find_by(student: student, company: company)
+  end
 end

--- a/db/migrate/20181217233842_remove_interview_result_reason_from_rankings.rb
+++ b/db/migrate/20181217233842_remove_interview_result_reason_from_rankings.rb
@@ -1,0 +1,5 @@
+class RemoveInterviewResultReasonFromRankings < ActiveRecord::Migration[5.0]
+  def change
+    remove_column :rankings, :interview_result_reason, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181211235707) do
+ActiveRecord::Schema.define(version: 20181217233842) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -83,9 +83,8 @@ ActiveRecord::Schema.define(version: 20181211235707) do
     t.integer  "company_id"
     t.integer  "student_preference"
     t.integer  "interview_result"
-    t.datetime "created_at",              null: false
-    t.datetime "updated_at",              null: false
-    t.string   "interview_result_reason"
+    t.datetime "created_at",         null: false
+    t.datetime "updated_at",         null: false
     t.index ["company_id"], name: "index_rankings_on_company_id", using: :btree
     t.index ["student_id"], name: "index_rankings_on_student_id", using: :btree
   end

--- a/test/models/ranking_test.rb
+++ b/test/models/ranking_test.rb
@@ -141,4 +141,18 @@ describe Ranking do
       expect(ranking.score).must_equal original_score + 1
     end
   end
+
+  describe '#interview' do
+    it 'returns the interview for this ranking' do
+      ranking = rankings(:ada_space)
+
+      expect(ranking.interview).must_equal interviews(:ada_space)
+    end
+
+      it 'returns nil if there is no interview for this ranking' do
+        ranking = rankings(:grace_stark)
+
+        expect(ranking.interview).must_be_nil
+      end
+  end
 end

--- a/test/models/ranking_test.rb
+++ b/test/models/ranking_test.rb
@@ -155,4 +155,37 @@ describe Ranking do
         expect(ranking.interview).must_be_nil
       end
   end
+
+  describe '#interview_result_reason' do
+    it 'returns the interview feedback\'s result explanation' do
+      ranking = rankings(:ada_space)
+
+      expect(ranking.interview_result_reason).must_equal 'This candidate was great!'
+    end
+
+    it 'returns the combined result of multiple feedbacks' do
+      ranking = rankings(:ada_space)
+      reason_orig = ranking.interview_result_reason
+
+      reason_new = 'This candidate was okay.'
+      interview = Interview.find_by(student: ranking.student, company: ranking.company)
+      interview.interview_feedbacks.create!(
+        interviewer_name: 'Interviewer Two',
+        interview_result: 3,
+        result_explanation: reason_new,
+        feedback_technical: '',
+        feedback_nontechnical: '',
+      )
+
+      expect(ranking.interview_result_reason).must_equal "#{reason_orig}\n#{reason_new}"
+    end
+
+    it 'returns nil if there are no interviews or feedback' do
+      ranking = rankings(:grace_freedom)
+      expect(ranking.interview_result_reason).must_be_nil
+
+      ranking = rankings(:grace_stark)
+      expect(ranking.interview_result_reason).must_be_nil
+    end
+  end
 end


### PR DESCRIPTION
I missed fixing this with the other changes to `Ranking` (or perhaps when the `Classroom` creation script was replaced, since that's what actually loaded the information into the DB).

This should make the interview notes available anywhere that we were able to see them previously, including on the actual placer UI (in the student tooltips) and in the classroom details page.