### PR TITLE
WIP:  get json to look right

### DIFF
--- a/app/models/classroom.rb
+++ b/app/models/classroom.rb
@@ -1,7 +1,7 @@
 class Classroom < ApplicationRecord
   has_many :students
   has_many :rankings, through: :students
-  has_many :companies
+  has_many :companies, -> { where("redirect_to is NULL") }
   has_many :placements
   has_many :pairings, through: :placements
   belongs_to :creator, class_name: "User"

--- a/app/models/ranking.rb
+++ b/app/models/ranking.rb
@@ -22,4 +22,10 @@ class Ranking < ApplicationRecord
   def company_id
     return self.interview.company_id
   end
+
+  def score
+    return 0 if !self.interview_result || !self.student_preference
+    
+    return self.interview_result * self.student_preference
+  end
 end

--- a/app/models/ranking.rb
+++ b/app/models/ranking.rb
@@ -14,4 +14,12 @@ class Ranking < ApplicationRecord
 
     interview.interview_feedbacks.order(updated_at: :asc).map(&:result_explanation).join("\n")
   end
+
+  def interview_result 
+    return self.interview.interview_result
+  end
+
+  def company_id
+    return self.interview.company_id
+  end
 end

--- a/app/views/placements/_placement.rabl
+++ b/app/views/placements/_placement.rabl
@@ -3,7 +3,7 @@ attributes :id, :whiteboard
 child :students do
   attributes :id, :name
   child :rankings do |ranking|
-      attributes :student_preference, :interview_result, :company_id, :score
+      attributes :student_preference, :interview_result, :company_id, :score, :interview_result_reason
   end
   child :interviews do |interview|  
     child :interview_feedbacks do |feedback|

--- a/app/views/placements/_placement.rabl
+++ b/app/views/placements/_placement.rabl
@@ -2,10 +2,10 @@ object @placement
 attributes :id, :whiteboard
 child :students do
   attributes :id, :name
-  child :interviews do |interview|
-    child :rankings do |ranking|
-      attributes :student_preference, :score
-    end
+  child :rankings do |ranking|
+      attributes :student_preference, :interview_result, :company_id, :score
+  end
+  child :interviews do |interview|  
     child :interview_feedbacks do |feedback|
       attributes :interview_result, :result_explanation
     end


### PR DESCRIPTION
I found a comment in `app/assests/javascripts/backbone/models/placement.js` which says:

```javascript

  // Incoming JSON looks like:
  // {
  //     "id": 545248419,
  //     "companies": [ {
  //         "id": 309418106,
  //         "name": "Stark Industries",
  //         "slots": 1
  //     }, ... ],
  //     "pairings": [ {
  //         "company_id": 309418106,
  //         "student_id": 225478506
  //     }, ... ],
  //     "students": [ {
  //         "id": 225478506,
  //         "name": "Ada Lovelace",
  //         "rankings": [ {
  //             "company_id": 739272092,
  //             "interview_result": 3,
  //             "student_preference": 4
  //         }, ... ]
  //     }, ... ]
  // }
```

Well I cloned the production DB to my machine local DB and am futzing with it.  This change should get the json to look right... but it's not working.  Grrr.  Rethinking a career as a VCR repairman.

